### PR TITLE
Add CloudKit sharing visibility for Collections

### DIFF
--- a/Traveling Snails Tests/TestUtilities/SQLiteDataTestBase.swift
+++ b/Traveling Snails Tests/TestUtilities/SQLiteDataTestBase.swift
@@ -32,7 +32,12 @@ final class SQLiteDataTestBase {
                         Lodging.self,
                         Transportation.self,
                         TransportationLeg.self,
-                        EmbeddedFileAttachment.self
+                        EmbeddedFileAttachment.self,
+                        Collection.self,
+                        BookItem.self,
+                        MovieItem.self,
+                        TVShowItem.self,
+                        RestaurantItem.self
                     )
                 }
             } catch {

--- a/Traveling Snails Tests/Unit Tests/Features/CollectionSharingTests.swift
+++ b/Traveling Snails Tests/Unit Tests/Features/CollectionSharingTests.swift
@@ -1,0 +1,316 @@
+//
+//  CollectionSharingTests.swift
+//  Traveling Snails Tests
+//
+
+import CloudKit
+import ComposableArchitecture
+import Foundation
+import SQLiteData
+import Testing
+@testable import Traveling_Snails
+
+@Suite("Collection Sharing Tests", .serialized)
+@MainActor
+struct CollectionSharingTests {
+
+    // MARK: - CollectionRow Model
+
+    @Test("CollectionRow isShared returns false when share is nil", .tags(.unit, .fast, .sharing))
+    func collectionRowNotShared() {
+        let row = CollectionRow(
+            collection: Collection(name: "Books", type: .book),
+            share: nil
+        )
+        #expect(row.isShared == false)
+        #expect(row.shareMessage == nil)
+        #expect(row.canWrite == true)
+    }
+
+    @Test("CollectionRow id matches collection id", .tags(.unit, .fast, .sharing))
+    func collectionRowId() {
+        let collection = Collection(name: "Movies", type: .movie)
+        let row = CollectionRow(collection: collection, share: nil)
+        #expect(row.id == collection.id)
+    }
+
+    // MARK: - Database: Collection CRUD
+
+    @Test("Collection can be created and read back", .tags(.unit, .fast, .sharing))
+    func collectionCRUD() async throws {
+        let db = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(db)
+
+        let collection = Collection(name: "My Books", type: .book)
+        try await db.write { db in
+            try Collection.upsert { collection }.execute(db)
+        }
+
+        let fetched = try await db.read { db in
+            try Collection.fetchAll(db)
+        }
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.name == "My Books")
+        #expect(fetched.first?.type == .book)
+    }
+
+    @Test("Collection can be deleted", .tags(.unit, .fast, .sharing))
+    func collectionDelete() async throws {
+        let db = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(db)
+
+        let collection = Collection(name: "To Delete", type: .movie)
+        try await db.write { db in
+            try Collection.upsert { collection }.execute(db)
+        }
+        try await db.write { db in
+            try Collection.find(collection.id).delete().execute(db)
+        }
+
+        let remaining = try await db.read { db in
+            try Collection.fetchAll(db)
+        }
+        #expect(remaining.isEmpty)
+    }
+
+    // MARK: - CollectionDetailFeature sharing actions
+
+    @Test("Share tapped sets isPreparingShare", .tags(.unit, .fast, .sharing))
+    func shareTappedSetsPreparingState() async throws {
+        let db = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(db)
+
+        let collection = Collection(name: "Shared List", type: .restaurant)
+        try await db.write { db in
+            try Collection.upsert { collection }.execute(db)
+        }
+
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(collection: collection)
+        ) {
+            CollectionDetailFeature()
+        } withDependencies: {
+            $0.defaultDatabase = db
+        }
+        store.exhaustivity = .off
+
+        await store.send(.shareTapped) {
+            $0.isPreparingShare = true
+            $0.shareError = nil
+        }
+    }
+
+    @Test("Share failed clears preparing state and sets error", .tags(.unit, .fast, .sharing))
+    func shareFailedSetsError() async throws {
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: Collection(name: "Test", type: .book)
+            )
+        ) {
+            CollectionDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.shareFailed("Network error")) {
+            $0.isPreparingShare = false
+            $0.shareError = "Network error"
+        }
+    }
+
+    @Test("Share dismissed clears share state and reloads status", .tags(.unit, .fast, .sharing))
+    func shareDismissedClearsState() async throws {
+        let db = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(db)
+
+        let collection = Collection(name: "Test", type: .book)
+        try await db.write { db in
+            try Collection.upsert { collection }.execute(db)
+        }
+
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: collection
+            )
+        ) {
+            CollectionDetailFeature()
+        } withDependencies: {
+            $0.defaultDatabase = db
+        }
+        store.exhaustivity = .off
+
+        await store.send(.shareDismissed) {
+            $0.sharedRecord = nil
+            $0.shareError = nil
+        }
+    }
+
+    // MARK: - Share status loading
+
+    @Test("Share status loaded updates state", .tags(.unit, .fast, .sharing))
+    func shareStatusLoaded() async throws {
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: Collection(name: "Test", type: .book)
+            )
+        ) {
+            CollectionDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        let participants = [
+            ShareParticipant(
+                id: "owner-123",
+                displayName: "Ryan",
+                role: .owner,
+                permission: .readWrite,
+                acceptanceStatus: .accepted
+            ),
+            ShareParticipant(
+                id: "member-456",
+                displayName: "Heather",
+                role: .privateUser,
+                permission: .readWrite,
+                acceptanceStatus: .accepted
+            ),
+        ]
+
+        await store.send(.shareStatusLoaded(isShared: true, canWrite: true, participants: participants)) {
+            $0.isLoadingParticipants = false
+            $0.isShared = true
+            $0.canWrite = true
+            $0.participants = participants
+        }
+    }
+
+    @Test("Share status loaded with read-only sets canWrite false", .tags(.unit, .fast, .sharing))
+    func shareStatusReadOnly() async throws {
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: Collection(name: "Test", type: .book)
+            )
+        ) {
+            CollectionDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.shareStatusLoaded(isShared: true, canWrite: false, participants: [])) {
+            $0.isLoadingParticipants = false
+            $0.isShared = true
+            $0.canWrite = false
+        }
+    }
+
+    @Test("Toggle participant sheet toggles state", .tags(.unit, .fast, .sharing))
+    func toggleParticipantSheet() async throws {
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: Collection(name: "Test", type: .book)
+            )
+        ) {
+            CollectionDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.toggleParticipantSheet) {
+            $0.showingParticipants = true
+        }
+
+        await store.send(.toggleParticipantSheet) {
+            $0.showingParticipants = false
+        }
+    }
+
+    // MARK: - ShareParticipant model
+
+    @Test("ShareParticipant owner is identified correctly", .tags(.unit, .fast, .sharing))
+    func shareParticipantOwner() {
+        let owner = ShareParticipant(
+            id: "owner-1",
+            displayName: "Ryan Smith",
+            role: .owner,
+            permission: .readWrite,
+            acceptanceStatus: .accepted
+        )
+        #expect(owner.isOwner == true)
+        #expect(owner.isPending == false)
+        #expect(owner.isReadOnly == false)
+        #expect(owner.roleLabel == "Owner")
+        #expect(owner.permissionLabel == "Can Edit")
+        #expect(owner.initials == "RS")
+    }
+
+    @Test("ShareParticipant pending read-only member", .tags(.unit, .fast, .sharing))
+    func shareParticipantPendingReadOnly() {
+        let member = ShareParticipant(
+            id: "member-1",
+            displayName: "Heather",
+            role: .privateUser,
+            permission: .readOnly,
+            acceptanceStatus: .pending
+        )
+        #expect(member.isOwner == false)
+        #expect(member.isPending == true)
+        #expect(member.isReadOnly == true)
+        #expect(member.roleLabel == "Member")
+        #expect(member.permissionLabel == "View Only")
+        #expect(member.initials == "HE")
+    }
+
+    // MARK: - Item Attribution
+
+    @Test("Attribution migration adds columns", .tags(.unit, .fast, .sharing))
+    func attributionMigration() async throws {
+        let db = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(db)
+
+        // Items should be creatable with attribution fields
+        let collection = Collection(name: "Test", type: .book)
+        try await db.write { db in
+            try Collection.upsert { collection }.execute(db)
+        }
+
+        let book = BookItem(
+            collectionID: collection.id,
+            title: "Test Book",
+            addedByUserRecordName: "user-123",
+            lastEditedByUserRecordName: "user-456"
+        )
+        try await db.write { db in
+            try BookItem.upsert { book }.execute(db)
+        }
+
+        let fetched = try await db.read { db in
+            try BookItem.fetchAll(db)
+        }
+        #expect(fetched.first?.addedByUserRecordName == "user-123")
+        #expect(fetched.first?.lastEditedByUserRecordName == "user-456")
+    }
+
+    @Test("Attribution defaults to empty string", .tags(.unit, .fast, .sharing))
+    func attributionDefaults() {
+        let item = RestaurantItem(collectionID: UUID(), title: "Test")
+        #expect(item.addedByUserRecordName == "")
+        #expect(item.lastEditedByUserRecordName == "")
+    }
+
+    @Test("CollectionItemProtocol exposes attribution", .tags(.unit, .fast, .sharing))
+    func protocolAttribution() {
+        let item: any CollectionItemProtocol = BookItem(
+            collectionID: UUID(),
+            title: "Book",
+            addedByUserRecordName: "user-abc"
+        )
+        #expect(item.addedByUserRecordName == "user-abc")
+        #expect(item.lastEditedByUserRecordName == "")
+    }
+
+    @Test("UserIdentityClient test value returns deterministic name", .tags(.unit, .fast, .sharing))
+    func userIdentityTestValue() async throws {
+        let client = UserIdentityClient.testValue
+        let name = try await client.currentUserRecordName()
+        #expect(name == "test-user-record-name")
+
+        let displayName = await client.displayName("any-record-name")
+        #expect(displayName == "Test User")
+    }
+}

--- a/Traveling Snails.xcodeproj/project.pbxproj
+++ b/Traveling Snails.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Traveling Snails/Traveling_Snails.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Traveling Snails/Traveling_Snails_macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 777XX46HDU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -317,7 +317,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ryanleewilliams.Traveling-Snails";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -337,7 +337,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Traveling Snails/Traveling_Snails.entitlements";
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "Traveling Snails/Traveling_Snails_macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 777XX46HDU;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_PREVIEWS = YES;
@@ -356,7 +356,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ryanleewilliams.Traveling-Snails";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -498,11 +498,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 777XX46HDU;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ryanleewilliams.Traveling-SnailsUnitTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -518,11 +518,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 777XX46HDU;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ryanleewilliams.Traveling-SnailsUnitTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/Traveling Snails/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Traveling Snails/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -125,6 +125,66 @@
       "idiom" : "ios-marketing",
       "scale" : "1x",
       "size" : "1024x1024"
+    },
+    {
+      "filename" : "AppIcon-mac-16.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "filename" : "AppIcon-mac-16@2x.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "filename" : "AppIcon-mac-32.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "filename" : "AppIcon-mac-32@2x.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "filename" : "AppIcon-mac-128.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "filename" : "AppIcon-mac-128@2x.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "filename" : "AppIcon-mac-256.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "filename" : "AppIcon-mac-256@2x.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "filename" : "AppIcon-mac-512.png",
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "filename" : "AppIcon-mac-512@2x.png",
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
     }
   ],
   "info" : {

--- a/Traveling Snails/Dependencies/UserIdentityClient.swift
+++ b/Traveling Snails/Dependencies/UserIdentityClient.swift
@@ -1,0 +1,80 @@
+//
+//  UserIdentityClient.swift
+//  Traveling Snails
+//
+
+import CloudKit
+import Dependencies
+import Foundation
+
+struct UserIdentityClient {
+    /// Returns the current user's CloudKit record name.
+    var currentUserRecordName: @Sendable () async throws -> String
+
+    /// Resolves a user record name to a display name from cache.
+    /// Returns "Unknown" if the record name hasn't been cached yet.
+    var displayName: @Sendable (String) async -> String
+
+    /// Caches display names from CKShare participants so they can be
+    /// resolved later without a network call. This should be called
+    /// whenever share participants are loaded.
+    var cacheParticipantNames: @Sendable ([CKShare.Participant]) async -> Void
+}
+
+extension UserIdentityClient: DependencyKey {
+    static let liveValue: UserIdentityClient = {
+        let cache = DisplayNameCache()
+        return UserIdentityClient(
+            currentUserRecordName: {
+                let recordID = try await CKContainer.default().userRecordID()
+                return recordID.recordName
+            },
+            displayName: { userRecordName in
+                await cache.resolve(userRecordName: userRecordName)
+            },
+            cacheParticipantNames: { participants in
+                await cache.cacheParticipants(participants)
+            }
+        )
+    }()
+
+    static let testValue = UserIdentityClient(
+        currentUserRecordName: { "test-user-record-name" },
+        displayName: { _ in "Test User" },
+        cacheParticipantNames: { _ in }
+    )
+}
+
+extension DependencyValues {
+    var userIdentityClient: UserIdentityClient {
+        get { self[UserIdentityClient.self] }
+        set { self[UserIdentityClient.self] = newValue }
+    }
+}
+
+// MARK: - Display name cache
+
+/// Caches user record name -> display name mappings.
+/// Populated from CKShare.Participant data when shares are loaded,
+/// avoiding the need for deprecated user identity discovery APIs.
+private actor DisplayNameCache {
+    private var cache: [String: String] = [:]
+
+    func resolve(userRecordName: String) -> String {
+        cache[userRecordName] ?? "Unknown"
+    }
+
+    func cacheParticipants(_ participants: [CKShare.Participant]) {
+        for participant in participants {
+            guard let recordName = participant.userIdentity.userRecordID?.recordName else {
+                continue
+            }
+            if let nameComponents = participant.userIdentity.nameComponents {
+                let name = PersonNameComponentsFormatter.localizedString(
+                    from: nameComponents, style: .default
+                )
+                cache[recordName] = name
+            }
+        }
+    }
+}

--- a/Traveling Snails/Features/BookItemDetailFeature.swift
+++ b/Traveling Snails/Features/BookItemDetailFeature.swift
@@ -47,6 +47,7 @@ struct BookItemDetailFeature {
 
     @Dependency(\.defaultDatabase) private var database
     @Dependency(\.googleBooksClient) private var googleBooksClient
+    @Dependency(\.userIdentityClient) private var userIdentityClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -71,9 +72,13 @@ struct BookItemDetailFeature {
             case .ratingChanged(let rating):
                 state.bookItem.rating = rating
                 let updated = state.bookItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try BookItem.upsert { updated }.execute(db)
+                        try BookItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
@@ -85,9 +90,13 @@ struct BookItemDetailFeature {
                     state.bookItem.setFinishedDate(Date())
                 }
                 let updated = state.bookItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try BookItem.upsert { updated }.execute(db)
+                        try BookItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
@@ -104,9 +113,13 @@ struct BookItemDetailFeature {
                 state.isEditing = false
                 state.bookItem.notes = state.editedNotes
                 let updated = state.bookItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try BookItem.upsert { updated }.execute(db)
+                        try BookItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 

--- a/Traveling Snails/Features/CollectionDetailFeature.swift
+++ b/Traveling Snails/Features/CollectionDetailFeature.swift
@@ -50,6 +50,11 @@ struct CollectionDetailFeature {
         var shareError: String?
         var isEditingName = false
         var editedName: String = ""
+        var participants: [ShareParticipant] = []
+        var isLoadingParticipants = false
+        var showingParticipants = false
+        var isShared = false
+        var canWrite = true
     }
 
     enum Action: Equatable {
@@ -67,6 +72,11 @@ struct CollectionDetailFeature {
         case shareCreated(SharedRecord)
         case shareFailed(String)
         case shareDismissed
+        case manageShareTapped
+        case toggleParticipantSheet
+
+        case loadShareStatus
+        case shareStatusLoaded(isShared: Bool, canWrite: Bool, participants: [ShareParticipant])
 
         case editNameTapped
         case editedNameChanged(String)
@@ -84,12 +94,16 @@ struct CollectionDetailFeature {
     @Dependency(\.defaultDatabase) private var database
     @Dependency(\.defaultSyncEngine) private var syncEngine
     @Dependency(\.mapKitSearchClient) private var mapKitSearchClient
+    @Dependency(\.userIdentityClient) private var userIdentityClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                return .send(.refreshCollection)
+                return .merge(
+                    .send(.refreshCollection),
+                    .send(.loadShareStatus)
+                )
 
             case .refreshCollection:
                 let collectionID = state.collection.id
@@ -161,6 +175,58 @@ struct CollectionDetailFeature {
             case .shareDismissed:
                 state.sharedRecord = nil
                 state.shareError = nil
+                return .send(.loadShareStatus)
+
+            case .manageShareTapped:
+                guard !state.isPreparingShare else { return .none }
+                state.isPreparingShare = true
+                let collection = state.collection
+                return .run { [syncEngine] send in
+                    do {
+                        let record = try await syncEngine.share(record: collection) { _ in }
+                        await send(.shareCreated(record))
+                    } catch {
+                        await send(.shareFailed(error.localizedDescription))
+                    }
+                }
+
+            case .toggleParticipantSheet:
+                state.showingParticipants.toggle()
+                return .none
+
+            case .loadShareStatus:
+                state.isLoadingParticipants = true
+                let metadataID = state.collection.syncMetadataID
+                return .run { [database, userIdentityClient] send in
+                    let share = try? await database.read { db in
+                        try SyncMetadata
+                            .find(metadataID)
+                            .select(\.share)
+                            .fetchOne(db)
+                            ?? nil
+                    }
+                    let isShared = share != nil
+                    var participants: [ShareParticipant] = []
+                    var canWrite = true
+                    if let share {
+                        await userIdentityClient.cacheParticipantNames(share.participants)
+                        participants = ShareParticipant.from(share: share)
+                        let currentUser = share.currentUserParticipant
+                        canWrite = currentUser?.permission == .readWrite
+                            || share.owner == currentUser
+                    }
+                    await send(.shareStatusLoaded(
+                        isShared: isShared,
+                        canWrite: canWrite,
+                        participants: participants
+                    ))
+                }
+
+            case .shareStatusLoaded(let isShared, let canWrite, let participants):
+                state.isLoadingParticipants = false
+                state.isShared = isShared
+                state.canWrite = canWrite
+                state.participants = participants
                 return .none
 
             case .editNameTapped:

--- a/Traveling Snails/Features/CollectionsFeature.swift
+++ b/Traveling Snails/Features/CollectionsFeature.swift
@@ -3,6 +3,7 @@
 //  Traveling Snails
 //
 
+import CloudKit
 import ComposableArchitecture
 import Foundation
 import SQLiteData
@@ -11,8 +12,22 @@ import SQLiteData
 struct CollectionsFeature {
     @ObservableState
     struct State {
-        @FetchAll(Collection.order { $0.createdDate.desc() })
-        var collections: [Collection] = []
+        @FetchAll(
+            Collection
+                .order { $0.createdDate.desc() }
+                .leftJoin(SyncMetadata.all) { $0.syncMetadataID.eq($1.id) }
+                .select {
+                    CollectionRow.Columns(
+                        collection: $0,
+                        share: $1.share
+                    )
+                }
+        )
+        var collectionRows: [CollectionRow] = []
+
+        var collections: [Collection] {
+            collectionRows.map(\.collection)
+        }
     }
 
     enum Action {

--- a/Traveling Snails/Features/MediaSearchFeature.swift
+++ b/Traveling Snails/Features/MediaSearchFeature.swift
@@ -115,6 +115,7 @@ struct MediaSearchFeature {
     @Dependency(\.tmdbClient) private var tmdbClient
     @Dependency(\.mapKitSearchClient) private var mapKitSearchClient
     @Dependency(\.defaultDatabase) private var database
+    @Dependency(\.userIdentityClient) private var userIdentityClient
 
     private enum CancelID { case search }
 
@@ -184,9 +185,13 @@ struct MediaSearchFeature {
                 switch result {
                 case .book(let bookResult):
                     let bookItem = bookResult.toBookItem(collectionID: collectionID)
-                    return .run { send in
+                    return .run { [userIdentityClient] send in
+                        let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                         try await database.write { db in
                             try BookItem.upsert { bookItem }.execute(db)
+                            try BookItem.find(bookItem.id)
+                                .update { $0.addedByUserRecordName = #bind(recordName) }
+                                .execute(db)
                         }
                         if !bookItem.coverImageURL.isEmpty {
                             if let imageData = await MediaCacheService.shared.downloadCoverImage(from: bookItem.coverImageURL) {
@@ -202,9 +207,13 @@ struct MediaSearchFeature {
 
                 case .movie(let movieResult):
                     let movieItem = movieResult.toMovieItem(collectionID: collectionID)
-                    return .run { send in
+                    return .run { [userIdentityClient] send in
+                        let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                         try await database.write { db in
                             try MovieItem.upsert { movieItem }.execute(db)
+                            try MovieItem.find(movieItem.id)
+                                .update { $0.addedByUserRecordName = #bind(recordName) }
+                                .execute(db)
                         }
                         if !movieItem.posterURL.isEmpty {
                             if let imageData = await MediaCacheService.shared.downloadCoverImage(from: movieItem.posterURL) {
@@ -220,9 +229,13 @@ struct MediaSearchFeature {
 
                 case .tvShow(let tvResult):
                     let tvItem = tvResult.toTVShowItem(collectionID: collectionID)
-                    return .run { send in
+                    return .run { [userIdentityClient] send in
+                        let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                         try await database.write { db in
                             try TVShowItem.upsert { tvItem }.execute(db)
+                            try TVShowItem.find(tvItem.id)
+                                .update { $0.addedByUserRecordName = #bind(recordName) }
+                                .execute(db)
                         }
                         if !tvItem.posterURL.isEmpty {
                             if let imageData = await MediaCacheService.shared.downloadCoverImage(from: tvItem.posterURL) {
@@ -238,9 +251,13 @@ struct MediaSearchFeature {
 
                 case .restaurant(let restaurantResult):
                     let restaurantItem = restaurantResult.toRestaurantItem(collectionID: collectionID)
-                    return .run { send in
+                    return .run { [userIdentityClient] send in
+                        let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                         try await database.write { db in
                             try RestaurantItem.upsert { restaurantItem }.execute(db)
+                            try RestaurantItem.find(restaurantItem.id)
+                                .update { $0.addedByUserRecordName = #bind(recordName) }
+                                .execute(db)
                         }
                         await send(.itemSaved)
                         if restaurantItem.hasCoordinate || !restaurantItem.websiteURL.isEmpty {

--- a/Traveling Snails/Features/MovieItemDetailFeature.swift
+++ b/Traveling Snails/Features/MovieItemDetailFeature.swift
@@ -46,6 +46,7 @@ struct MovieItemDetailFeature {
 
     @Dependency(\.defaultDatabase) private var database
     @Dependency(\.tmdbClient) private var tmdbClient
+    @Dependency(\.userIdentityClient) private var userIdentityClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -70,9 +71,13 @@ struct MovieItemDetailFeature {
             case .ratingChanged(let rating):
                 state.movieItem.rating = rating
                 let updated = state.movieItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try MovieItem.upsert { updated }.execute(db)
+                        try MovieItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
@@ -82,9 +87,13 @@ struct MovieItemDetailFeature {
                     state.movieItem.setWatchedDate(Date())
                 }
                 let updated = state.movieItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try MovieItem.upsert { updated }.execute(db)
+                        try MovieItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
@@ -101,9 +110,13 @@ struct MovieItemDetailFeature {
                 state.isEditing = false
                 state.movieItem.notes = state.editedNotes
                 let updated = state.movieItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try MovieItem.upsert { updated }.execute(db)
+                        try MovieItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
@@ -118,9 +131,13 @@ struct MovieItemDetailFeature {
                     state.movieItem.clearWatchedDate()
                 }
                 let updated = state.movieItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try MovieItem.upsert { updated }.execute(db)
+                        try MovieItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 

--- a/Traveling Snails/Features/RestaurantItemDetailFeature.swift
+++ b/Traveling Snails/Features/RestaurantItemDetailFeature.swift
@@ -58,6 +58,7 @@ struct RestaurantItemDetailFeature {
 
     @Dependency(\.defaultDatabase) private var database
     @Dependency(\.mapKitSearchClient) private var mapKitSearchClient
+    @Dependency(\.userIdentityClient) private var userIdentityClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -82,9 +83,13 @@ struct RestaurantItemDetailFeature {
             case .ratingChanged(let rating):
                 state.restaurantItem.rating = rating
                 let updated = state.restaurantItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try RestaurantItem.upsert { updated }.execute(db)
+                        try RestaurantItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 } catch: { error, _ in
                     Logger.shared.error("Failed to save rating: \(error)", category: .database)
@@ -96,9 +101,13 @@ struct RestaurantItemDetailFeature {
                     state.restaurantItem.setVisitedDate(Date())
                 }
                 let updated = state.restaurantItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try RestaurantItem.upsert { updated }.execute(db)
+                        try RestaurantItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 } catch: { error, _ in
                     Logger.shared.error("Failed to save status: \(error)", category: .database)
@@ -117,9 +126,13 @@ struct RestaurantItemDetailFeature {
                 state.isEditing = false
                 state.restaurantItem.notes = state.editedNotes
                 let updated = state.restaurantItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try RestaurantItem.upsert { updated }.execute(db)
+                        try RestaurantItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 } catch: { error, _ in
                     Logger.shared.error("Failed to save notes: \(error)", category: .database)
@@ -136,9 +149,13 @@ struct RestaurantItemDetailFeature {
                     state.restaurantItem.clearVisitedDate()
                 }
                 let updated = state.restaurantItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try RestaurantItem.upsert { updated }.execute(db)
+                        try RestaurantItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 } catch: { error, _ in
                     Logger.shared.error("Failed to save visited date: \(error)", category: .database)

--- a/Traveling Snails/Features/TVShowItemDetailFeature.swift
+++ b/Traveling Snails/Features/TVShowItemDetailFeature.swift
@@ -44,6 +44,7 @@ struct TVShowItemDetailFeature {
 
     @Dependency(\.defaultDatabase) private var database
     @Dependency(\.tmdbClient) private var tmdbClient
+    @Dependency(\.userIdentityClient) private var userIdentityClient
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -68,18 +69,26 @@ struct TVShowItemDetailFeature {
             case .ratingChanged(let rating):
                 state.tvShowItem.rating = rating
                 let updated = state.tvShowItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try TVShowItem.upsert { updated }.execute(db)
+                        try TVShowItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
             case .statusChanged(let status):
                 state.tvShowItem.status = status
                 let updated = state.tvShowItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try TVShowItem.upsert { updated }.execute(db)
+                        try TVShowItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 
@@ -96,9 +105,13 @@ struct TVShowItemDetailFeature {
                 state.isEditing = false
                 state.tvShowItem.notes = state.editedNotes
                 let updated = state.tvShowItem
-                return .run { _ in
+                return .run { [userIdentityClient] _ in
+                    let recordName = (try? await userIdentityClient.currentUserRecordName()) ?? ""
                     try await database.write { db in
                         try TVShowItem.upsert { updated }.execute(db)
+                        try TVShowItem.find(updated.id)
+                            .update { $0.lastEditedByUserRecordName = #bind(recordName) }
+                            .execute(db)
                     }
                 }
 

--- a/Traveling Snails/Models/BookItem.swift
+++ b/Traveling Snails/Models/BookItem.swift
@@ -29,6 +29,8 @@ nonisolated struct BookItem: Hashable, Identifiable {
     var notes: String
     var sortOrder: Int
     var createdDate: Date
+    var addedByUserRecordName: String
+    var lastEditedByUserRecordName: String
 
     init(
         id: UUID = UUID(),
@@ -51,7 +53,9 @@ nonisolated struct BookItem: Hashable, Identifiable {
         hasFinishedDate: Bool = false,
         notes: String = "",
         sortOrder: Int = 0,
-        createdDate: Date = Date()
+        createdDate: Date = Date(),
+        addedByUserRecordName: String = "",
+        lastEditedByUserRecordName: String = ""
     ) {
         self.id = id
         self.collectionID = collectionID
@@ -74,6 +78,8 @@ nonisolated struct BookItem: Hashable, Identifiable {
         self.notes = notes
         self.sortOrder = sortOrder
         self.createdDate = createdDate
+        self.addedByUserRecordName = addedByUserRecordName
+        self.lastEditedByUserRecordName = lastEditedByUserRecordName
     }
 
     var effectiveStartedDate: Date? {

--- a/Traveling Snails/Models/CollectionRow.swift
+++ b/Traveling Snails/Models/CollectionRow.swift
@@ -1,0 +1,43 @@
+//
+//  CollectionRow.swift
+//  Traveling Snails
+//
+
+import CloudKit
+import SQLiteData
+
+@Selection
+struct CollectionRow: Identifiable {
+    var id: Collection.ID { collection.id }
+    var collection: Collection
+    @Column(as: CKShare?.SystemFieldsRepresentation.self)
+    var share: CKShare?
+
+    var isShared: Bool { share != nil }
+
+    var shareMessage: String? {
+        guard let share else { return nil }
+        if share.owner == share.currentUserParticipant {
+            let participantNames = share.participants
+                .filter { $0 != share.currentUserParticipant }
+                .compactMap { $0.userIdentity.nameComponents?.formatted() }
+                .joined(separator: ", ")
+            if !participantNames.isEmpty {
+                return "Shared with \(participantNames)"
+            } else {
+                return "Shared"
+            }
+        } else if let ownerName = share.owner.userIdentity.nameComponents?.formatted() {
+            return "Shared by \(ownerName)"
+        } else {
+            return nil
+        }
+    }
+
+    var canWrite: Bool {
+        guard let share else { return true }
+        let participant = share.currentUserParticipant
+        return participant?.permission == .readWrite
+            || share.owner == participant
+    }
+}

--- a/Traveling Snails/Models/MovieItem.swift
+++ b/Traveling Snails/Models/MovieItem.swift
@@ -31,6 +31,8 @@ nonisolated struct MovieItem: Hashable, Identifiable {
     var createdDate: Date
     var voteAverage: Double
     var originalLanguage: String
+    var addedByUserRecordName: String
+    var lastEditedByUserRecordName: String
 
     init(
         id: UUID = UUID(),
@@ -55,7 +57,9 @@ nonisolated struct MovieItem: Hashable, Identifiable {
         sortOrder: Int = 0,
         createdDate: Date = Date(),
         voteAverage: Double = 0,
-        originalLanguage: String = ""
+        originalLanguage: String = "",
+        addedByUserRecordName: String = "",
+        lastEditedByUserRecordName: String = ""
     ) {
         self.id = id
         self.collectionID = collectionID
@@ -80,6 +84,8 @@ nonisolated struct MovieItem: Hashable, Identifiable {
         self.createdDate = createdDate
         self.voteAverage = voteAverage
         self.originalLanguage = originalLanguage
+        self.addedByUserRecordName = addedByUserRecordName
+        self.lastEditedByUserRecordName = lastEditedByUserRecordName
     }
 
     var effectiveWatchedDate: Date? {

--- a/Traveling Snails/Models/Protocols/CollectionItemProtocol.swift
+++ b/Traveling Snails/Models/Protocols/CollectionItemProtocol.swift
@@ -16,6 +16,8 @@ protocol CollectionItemProtocol: Identifiable, Equatable {
     var externalID: String { get set }
     var sortOrder: Int { get set }
     var createdDate: Date { get }
+    var addedByUserRecordName: String { get }
+    var lastEditedByUserRecordName: String { get }
 
     static var collectionType: CollectionType { get }
     var displaySubtitle: String { get }

--- a/Traveling Snails/Models/RestaurantItem.swift
+++ b/Traveling Snails/Models/RestaurantItem.swift
@@ -34,6 +34,8 @@ nonisolated struct RestaurantItem: Hashable, Identifiable {
     var notes: String
     var sortOrder: Int
     var createdDate: Date
+    var addedByUserRecordName: String
+    var lastEditedByUserRecordName: String
 
     init(
         id: UUID = UUID(),
@@ -61,7 +63,9 @@ nonisolated struct RestaurantItem: Hashable, Identifiable {
         hasVisitedDate: Bool = false,
         notes: String = "",
         sortOrder: Int = 0,
-        createdDate: Date = Date()
+        createdDate: Date = Date(),
+        addedByUserRecordName: String = "",
+        lastEditedByUserRecordName: String = ""
     ) {
         self.id = id
         self.collectionID = collectionID
@@ -89,6 +93,8 @@ nonisolated struct RestaurantItem: Hashable, Identifiable {
         self.notes = notes
         self.sortOrder = sortOrder
         self.createdDate = createdDate
+        self.addedByUserRecordName = addedByUserRecordName
+        self.lastEditedByUserRecordName = lastEditedByUserRecordName
     }
 
     var effectiveVisitedDate: Date? {

--- a/Traveling Snails/Models/ShareParticipant.swift
+++ b/Traveling Snails/Models/ShareParticipant.swift
@@ -1,0 +1,65 @@
+//
+//  ShareParticipant.swift
+//  Traveling Snails
+//
+
+import CloudKit
+import Foundation
+
+struct ShareParticipant: Identifiable, Equatable {
+    let id: String
+    let displayName: String
+    let role: CKShare.ParticipantRole
+    let permission: CKShare.ParticipantPermission
+    let acceptanceStatus: CKShare.ParticipantAcceptanceStatus
+
+    var isOwner: Bool { role == .owner }
+    var isPending: Bool { acceptanceStatus == .pending }
+    var isReadOnly: Bool { permission == .readOnly }
+
+    var permissionLabel: String {
+        switch permission {
+        case .unknown: return "Unknown"
+        case .none: return "No Access"
+        case .readOnly: return "View Only"
+        case .readWrite: return "Can Edit"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    var roleLabel: String {
+        isOwner ? "Owner" : "Member"
+    }
+
+    var initials: String {
+        let parts = displayName.split(separator: " ")
+        if parts.count >= 2 {
+            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String(displayName.prefix(2)).uppercased()
+    }
+
+    static func from(ckParticipant: CKShare.Participant) -> ShareParticipant {
+        let name = ckParticipant.userIdentity.nameComponents
+            .flatMap { PersonNameComponentsFormatter.localizedString(from: $0, style: .default) }
+            ?? "Unknown"
+
+        return ShareParticipant(
+            id: ckParticipant.userIdentity.userRecordID?.recordName ?? UUID().uuidString,
+            displayName: name,
+            role: ckParticipant.role,
+            permission: ckParticipant.permission,
+            acceptanceStatus: ckParticipant.acceptanceStatus
+        )
+    }
+
+    static func from(share: CKShare) -> [ShareParticipant] {
+        share.participants
+            .map { ShareParticipant.from(ckParticipant: $0) }
+            .sorted { lhs, rhs in
+                if lhs.isOwner != rhs.isOwner { return lhs.isOwner }
+                if lhs.isPending != rhs.isPending { return !lhs.isPending }
+                return lhs.displayName < rhs.displayName
+            }
+    }
+}

--- a/Traveling Snails/Models/TVShowItem.swift
+++ b/Traveling Snails/Models/TVShowItem.swift
@@ -33,6 +33,8 @@ nonisolated struct TVShowItem: Hashable, Identifiable {
     var voteAverage: Double
     var originalLanguage: String
     var network: String
+    var addedByUserRecordName: String
+    var lastEditedByUserRecordName: String
 
     init(
         id: UUID = UUID(),
@@ -59,7 +61,9 @@ nonisolated struct TVShowItem: Hashable, Identifiable {
         createdDate: Date = Date(),
         voteAverage: Double = 0,
         originalLanguage: String = "",
-        network: String = ""
+        network: String = "",
+        addedByUserRecordName: String = "",
+        lastEditedByUserRecordName: String = ""
     ) {
         self.id = id
         self.collectionID = collectionID
@@ -86,6 +90,8 @@ nonisolated struct TVShowItem: Hashable, Identifiable {
         self.voteAverage = voteAverage
         self.originalLanguage = originalLanguage
         self.network = network
+        self.addedByUserRecordName = addedByUserRecordName
+        self.lastEditedByUserRecordName = lastEditedByUserRecordName
     }
 
     var coverImageURL: String { posterURL }

--- a/Traveling Snails/Persistence/DatabaseMigrator.swift
+++ b/Traveling Snails/Persistence/DatabaseMigrator.swift
@@ -534,5 +534,16 @@ func makeMigrator() -> DatabaseMigrator {
         try #sql("ALTER TABLE \"restaurantItems\" ADD COLUMN \"coverImageType\" TEXT DEFAULT ''").execute(db)
     }
 
+    migrator.registerMigration("Add item attribution columns") { db in
+        try #sql("ALTER TABLE \"bookItems\" ADD COLUMN \"addedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"bookItems\" ADD COLUMN \"lastEditedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"movieItems\" ADD COLUMN \"addedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"movieItems\" ADD COLUMN \"lastEditedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"tvShowItems\" ADD COLUMN \"addedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"tvShowItems\" ADD COLUMN \"lastEditedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"restaurantItems\" ADD COLUMN \"addedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+        try #sql("ALTER TABLE \"restaurantItems\" ADD COLUMN \"lastEditedByUserRecordName\" TEXT DEFAULT ''").execute(db)
+    }
+
     return migrator
 }

--- a/Traveling Snails/Views/Collections/CollectionDetailView.swift
+++ b/Traveling Snails/Views/Collections/CollectionDetailView.swift
@@ -3,6 +3,7 @@
 //  Traveling Snails
 //
 
+import CloudKit
 import ComposableArchitecture
 import SQLiteData
 import SwiftUI
@@ -63,10 +64,12 @@ struct CollectionDetailView: View {
                             }
                         }
                         .contextMenu {
-                            Button {
-                                store.send(.addItemTapped)
-                            } label: {
-                                Label("Add \(collection.type.singularName)…", systemImage: "plus")
+                            if store.state.canWrite {
+                                Button {
+                                    store.send(.addItemTapped)
+                                } label: {
+                                    Label("Add \(collection.type.singularName)…", systemImage: "plus")
+                                }
                             }
                         }
                 } else {
@@ -79,10 +82,12 @@ struct CollectionDetailView: View {
                         }
                     }
                     .contextMenu {
-                        Button {
-                            store.send(.addItemTapped)
-                        } label: {
-                            Label("Add \(collection.type.singularName)…", systemImage: "plus")
+                        if store.state.canWrite {
+                            Button {
+                                store.send(.addItemTapped)
+                            } label: {
+                                Label("Add \(collection.type.singularName)…", systemImage: "plus")
+                            }
                         }
                     }
                 }
@@ -120,16 +125,35 @@ struct CollectionDetailView: View {
                             }
                         }
 
-                        Button {
-                            store.send(.addItemTapped)
-                        } label: {
-                            Image(systemName: "plus")
+                        if store.state.isShared && !store.state.participants.isEmpty {
+                            Button {
+                                store.send(.toggleParticipantSheet)
+                            } label: {
+                                ParticipantAvatarsView(participants: store.state.participants)
+                            }
+                            .buttonStyle(.plain)
                         }
 
-                        Button {
-                            store.send(.shareTapped)
-                        } label: {
-                            Image(systemName: "square.and.arrow.up")
+                        if store.state.canWrite {
+                            Button {
+                                store.send(.addItemTapped)
+                            } label: {
+                                Image(systemName: "plus")
+                            }
+                        }
+
+                        if store.state.isShared {
+                            Button {
+                                store.send(.manageShareTapped)
+                            } label: {
+                                Image(systemName: "person.2")
+                            }
+                        } else {
+                            Button {
+                                store.send(.shareTapped)
+                            } label: {
+                                Image(systemName: "square.and.arrow.up")
+                            }
                         }
                     }
                 }
@@ -152,6 +176,54 @@ struct CollectionDetailView: View {
                     MediaSearchFeature()
                 }
             )
+        }
+        #if os(iOS)
+        .sheet(
+            item: Binding(
+                get: { store.sharedRecord },
+                set: { _ in store.send(.shareDismissed) }
+            )
+        ) { sharedRecord in
+            NavigationStack {
+                CloudSharingView(sharedRecord: sharedRecord)
+            }
+        }
+        #elseif os(macOS)
+        .background {
+            if store.sharedRecord != nil {
+                MacCloudSharingView(
+                    sharedRecord: store.sharedRecord!,
+                    onDismiss: { store.send(.shareDismissed) }
+                )
+                .frame(width: 0, height: 0)
+            }
+        }
+        #endif
+        .alert(
+            "Sharing Error",
+            isPresented: Binding(
+                get: { store.shareError != nil },
+                set: { if !$0 { store.send(.shareDismissed) } }
+            )
+        ) {
+            Button("OK") { store.send(.shareDismissed) }
+        } message: {
+            if let error = store.shareError {
+                Text(error)
+            }
+        }
+        .popover(isPresented: Binding(
+            get: { store.state.showingParticipants },
+            set: { if !$0 { store.send(.toggleParticipantSheet) } }
+        )) {
+            ParticipantListView(
+                participants: store.state.participants,
+                onManageSharing: {
+                    store.send(.toggleParticipantSheet)
+                    store.send(.manageShareTapped)
+                }
+            )
+            .frame(minWidth: 280)
         }
         .onAppear { store.send(.onAppear) }
         .onChange(of: restaurantItems) { _, items in

--- a/Traveling Snails/Views/Collections/CollectionsListView.swift
+++ b/Traveling Snails/Views/Collections/CollectionsListView.swift
@@ -19,10 +19,10 @@ struct CollectionsListView: View {
     @State private var renameText = ""
 
     var body: some View {
-        let collections = store.state.collections
+        let rows = store.state.collectionRows
 
         List(selection: $selectedCollectionID) {
-            collectionsContent(collections: collections)
+            collectionsContent(rows: rows)
         }
         .contextMenu {
             newCollectionMenu
@@ -56,12 +56,12 @@ struct CollectionsListView: View {
     }
 
     @ViewBuilder
-    private func collectionsContent(collections: [Collection]) -> some View {
+    private func collectionsContent(rows: [CollectionRow]) -> some View {
         ForEach(CollectionType.allCases, id: \.self) { type in
-            collectionSection(type: type, collections: collections)
+            collectionSection(type: type, rows: rows)
         }
 
-        if collections.isEmpty {
+        if rows.isEmpty {
             ContentUnavailableView {
                 Label("No Collections", systemImage: "square.stack")
             } description: {
@@ -91,20 +91,21 @@ struct CollectionsListView: View {
     }
 
     @ViewBuilder
-    private func collectionSection(type: CollectionType, collections: [Collection]) -> some View {
-        let filtered = collections.filter { $0.type == type }
+    private func collectionSection(type: CollectionType, rows: [CollectionRow]) -> some View {
+        let filtered = rows.filter { $0.collection.type == type }
         if !filtered.isEmpty {
             Section(type.displayName) {
-                ForEach(filtered) { collection in
-                    collectionRow(collection: collection)
+                ForEach(filtered) { row in
+                    collectionRowView(row: row)
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func collectionRow(collection: Collection) -> some View {
-        CollectionRowView(collection: collection)
+    private func collectionRowView(row: CollectionRow) -> some View {
+        let collection = row.collection
+        CollectionRowView(collection: collection, isShared: row.isShared, shareMessage: row.shareMessage)
             .tag(collection.id)
             .onTapGesture {
                 onCollectionSelected(collection)
@@ -206,6 +207,8 @@ struct CollectionsListView: View {
 
 struct CollectionRowView: View {
     let collection: Collection
+    var isShared: Bool = false
+    var shareMessage: String?
 
     var body: some View {
         HStack(spacing: 12) {
@@ -214,11 +217,25 @@ struct CollectionRowView: View {
                 .foregroundStyle(collection.type.color)
                 .frame(width: 32, height: 32)
 
-            Text(collection.name.isEmpty ? collection.type.singularName : collection.name)
-                .font(.body)
-                .fontWeight(.medium)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(collection.name.isEmpty ? collection.type.singularName : collection.name)
+                    .font(.body)
+                    .fontWeight(.medium)
+
+                if let shareMessage {
+                    Text(shareMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
 
             Spacer()
+
+            if isShared {
+                Image(systemName: "person.2.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .contentShape(Rectangle())
     }

--- a/Traveling Snails/Views/Collections/ParticipantListView.swift
+++ b/Traveling Snails/Views/Collections/ParticipantListView.swift
@@ -1,0 +1,125 @@
+//
+//  ParticipantListView.swift
+//  Traveling Snails
+//
+
+import SwiftUI
+
+struct ParticipantListView: View {
+    let participants: [ShareParticipant]
+    let onManageSharing: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(participants) { participant in
+                participantRow(participant)
+                if participant.id != participants.last?.id {
+                    Divider()
+                        .padding(.leading, 52)
+                }
+            }
+
+            Divider()
+                .padding(.vertical, 8)
+
+            Button(action: onManageSharing) {
+                Label("Manage Sharing", systemImage: "person.badge.plus")
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func participantRow(_ participant: ShareParticipant) -> some View {
+        HStack(spacing: 12) {
+            // Initials avatar
+            Text(participant.initials)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.white)
+                .frame(width: 32, height: 32)
+                .background(
+                    participant.isOwner
+                        ? Color.blue
+                        : Color.gray
+                )
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(participant.displayName)
+                        .font(.body)
+                        .fontWeight(.medium)
+
+                    if participant.isOwner {
+                        Text("Owner")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.blue.opacity(0.15))
+                            .foregroundStyle(.blue)
+                            .clipShape(Capsule())
+                    }
+                }
+
+                Text(participant.permissionLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if participant.isPending {
+                Text("Pending")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .opacity(participant.isPending ? 0.6 : 1.0)
+    }
+}
+
+// MARK: - Compact participant indicator for toolbar
+
+struct ParticipantAvatarsView: View {
+    let participants: [ShareParticipant]
+
+    private var displayCount: Int {
+        min(participants.count, 3)
+    }
+
+    var body: some View {
+        HStack(spacing: -6) {
+            ForEach(participants.prefix(displayCount)) { participant in
+                Text(participant.initials)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 22, height: 22)
+                    .background(participant.isOwner ? Color.blue : Color.gray)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Color.clear, lineWidth: 1.5)
+                    )
+            }
+
+            if participants.count > 3 {
+                Text("+\(participants.count - 3)")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(.quaternary)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(Color.clear, lineWidth: 1.5)
+                    )
+            }
+        }
+    }
+}

--- a/Traveling Snails/Views/Sharing/MacCloudSharingView.swift
+++ b/Traveling Snails/Views/Sharing/MacCloudSharingView.swift
@@ -1,0 +1,95 @@
+//
+//  MacCloudSharingView.swift
+//  Traveling Snails
+//
+
+#if os(macOS)
+import AppKit
+import CloudKit
+import Dependencies
+import SQLiteData
+import SwiftUI
+
+struct MacCloudSharingView: NSViewRepresentable {
+    let sharedRecord: SharedRecord
+    let onDismiss: () -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            context.coordinator.presentSharingService(from: view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            sharedRecord: sharedRecord,
+            onDismiss: onDismiss
+        )
+    }
+
+    final class Coordinator: NSObject, NSCloudSharingServiceDelegate {
+        let sharedRecord: SharedRecord
+        let onDismiss: () -> Void
+
+        init(
+            sharedRecord: SharedRecord,
+            onDismiss: @escaping () -> Void
+        ) {
+            self.sharedRecord = sharedRecord
+            self.onDismiss = onDismiss
+        }
+
+        func presentSharingService(from view: NSView) {
+            guard let service = NSSharingService(named: .cloudSharing) else {
+                onDismiss()
+                return
+            }
+            service.delegate = self
+
+            let itemProvider = NSItemProvider()
+            itemProvider.registerCloudKitShare(
+                sharedRecord.share,
+                container: CKContainer.default()
+            )
+
+            service.perform(withItems: [itemProvider])
+        }
+
+        // MARK: - NSCloudSharingServiceDelegate
+
+        func sharingService(
+            _ sharingService: NSSharingService,
+            didCompleteForItems items: [Any],
+            error: (any Error)?
+        ) {
+            onDismiss()
+        }
+
+        func sharingService(
+            _ sharingService: NSSharingService,
+            didSave share: CKShare
+        ) {
+            // Share was saved successfully
+        }
+
+        func sharingService(
+            _ sharingService: NSSharingService,
+            didStopSharing share: CKShare
+        ) {
+            // The SyncEngine will handle share cleanup on the next sync cycle
+            onDismiss()
+        }
+
+        func options(
+            for cloudKitSharingService: NSSharingService,
+            share provider: NSItemProvider
+        ) -> NSSharingService.CloudKitOptions {
+            return [.allowPublic, .allowPrivate, .allowReadOnly, .allowReadWrite]
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Closes #80

- Show which collections are shared in the sidebar with participant names
- Participant list popover with roles, permissions, and manage sharing access
- Track who added and last edited each item in shared collections
- CloudKit sharing support on both iOS (`CloudSharingView`) and macOS (`NSSharingService`)
- Hide edit controls for read-only participants
- Fix unassigned macOS app icon assets from #79

## New Files

- `CollectionRow.swift` — `@Selection` joining Collection to SyncMetadata for reactive share status
- `ShareParticipant.swift` — Maps CKShare.Participant to display-friendly model
- `ParticipantListView.swift` — Participant list + compact toolbar avatars
- `UserIdentityClient.swift` — TCA dependency for user record name + display name resolution
- `MacCloudSharingView.swift` — macOS CloudKit sharing via NSSharingService
- `CollectionSharingTests.swift` — 16 tests covering sharing, participants, and attribution

## Test plan

- [x] All 16 new sharing tests pass
- [x] Full existing test suite passes (0 failures)
- [x] Builds clean on both iOS and macOS (no errors, no warnings from our code)