### PR TITLE
Revert agvtool build number override

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -6,10 +6,3 @@
 # in Xcode locally.
 
 defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
-
-# Use the build number from the Xcode project instead of Xcode Cloud's
-# auto-incrementing counter, so TestFlight builds match what's in the repo.
-cd "$CI_PRIMARY_REPOSITORY_PATH"
-BUILD_NUMBER=$(xcrun agvtool what-version -terse)
-echo "Setting Xcode Cloud build number to project value: $BUILD_NUMBER"
-agvtool new-version -all "$BUILD_NUMBER"


### PR DESCRIPTION
## Summary
- Reverts the agvtool build number override added in #84 — it didn't work as expected with Xcode Cloud
- Lets Xcode Cloud manage its own auto-incrementing build number