### PR TITLE
Fix search sheet not auto-dismissing after adding a collection item

### DIFF
--- a/Traveling Snails Tests/Unit Tests/Features/MediaSearchFeatureMovieTests.swift
+++ b/Traveling Snails Tests/Unit Tests/Features/MediaSearchFeatureMovieTests.swift
@@ -118,6 +118,39 @@ struct MediaSearchFeatureMovieTests {
         #expect(items.first?.genres == "Action, Drama")
     }
 
+    // MARK: - Dismiss after save
+
+    @Test("itemSaved sets shouldDismiss to true", .tags(.unit, .fast, .parallel))
+    func itemSavedSetsShouldDismiss() async throws {
+        let dbq = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(dbq)
+
+        let collectionID = UUID()
+        let collection = Collection(id: collectionID, type: .movie)
+        try await dbq.write { db in
+            try Collection.insert { collection }.execute(db)
+        }
+
+        let result = makeResult(id: "dismiss-test", title: "Dismiss Movie")
+
+        let store = TestStore(
+            initialState: MediaSearchFeature.State(
+                collectionID: collectionID,
+                collectionType: .movie
+            )
+        ) {
+            MediaSearchFeature()
+        } withDependencies: {
+            $0.defaultDatabase = dbq
+        }
+        store.exhaustivity = .off
+
+        await store.send(.resultSelected(.movie(result)))
+        await store.receive(\.itemSaved) {
+            $0.shouldDismiss = true
+        }
+    }
+
     // MARK: - Search placeholder and sheet title
 
     @Test("Movie search has correct placeholder and title", .tags(.unit, .fast, .parallel))

--- a/Traveling Snails/Features/MediaSearchFeature.swift
+++ b/Traveling Snails/Features/MediaSearchFeature.swift
@@ -78,6 +78,7 @@ struct MediaSearchFeature {
         var isSearching = false
         var errorMessage: String?
         var hasSearched = false
+        var shouldDismiss = false
 
         var searchPlaceholder: String {
             switch collectionType {
@@ -194,6 +195,7 @@ struct MediaSearchFeature {
                                 .execute(db)
                         }
                         await RecentItemGuard.shared.guardBook(bookItem)
+                        await send(.itemSaved)
                         if !bookItem.coverImageURL.isEmpty {
                             if let imageData = await MediaCacheService.shared.downloadCoverImage(from: bookItem.coverImageURL) {
                                 try await database.write { db in
@@ -203,7 +205,6 @@ struct MediaSearchFeature {
                                 }
                             }
                         }
-                        await send(.itemSaved)
                     }
 
                 case .movie(let movieResult):
@@ -217,6 +218,7 @@ struct MediaSearchFeature {
                                 .execute(db)
                         }
                         await RecentItemGuard.shared.guardMovie(movieItem)
+                        await send(.itemSaved)
                         if !movieItem.posterURL.isEmpty {
                             if let imageData = await MediaCacheService.shared.downloadCoverImage(from: movieItem.posterURL) {
                                 try await database.write { db in
@@ -226,7 +228,6 @@ struct MediaSearchFeature {
                                 }
                             }
                         }
-                        await send(.itemSaved)
                     }
 
                 case .tvShow(let tvResult):
@@ -240,6 +241,7 @@ struct MediaSearchFeature {
                                 .execute(db)
                         }
                         await RecentItemGuard.shared.guardTVShow(tvItem)
+                        await send(.itemSaved)
                         if !tvItem.posterURL.isEmpty {
                             if let imageData = await MediaCacheService.shared.downloadCoverImage(from: tvItem.posterURL) {
                                 try await database.write { db in
@@ -249,7 +251,6 @@ struct MediaSearchFeature {
                                 }
                             }
                         }
-                        await send(.itemSaved)
                     }
 
                 case .restaurant(let restaurantResult):
@@ -271,6 +272,7 @@ struct MediaSearchFeature {
                 }
 
             case .itemSaved:
+                state.shouldDismiss = true
                 return .none
 
             case .generateSnapshot(let restaurantItem):

--- a/Traveling Snails/Views/Collections/MediaSearchSheet.swift
+++ b/Traveling Snails/Views/Collections/MediaSearchSheet.swift
@@ -66,6 +66,9 @@ struct MediaSearchSheet: View {
                 }
             }
         }
+        .onChange(of: store.shouldDismiss) { _, shouldDismiss in
+            if shouldDismiss { dismiss() }
+        }
         #if os(macOS)
         .frame(minWidth: 500, minHeight: 400)
         #endif


### PR DESCRIPTION
Closes #89

## Summary
- `MediaSearchFeature` gains a `shouldDismiss` state flag, set to `true` when `.itemSaved` fires
- `MediaSearchSheet` observes `shouldDismiss` via `.onChange` and calls `dismiss()` immediately — same pattern used throughout the rest of the app
- For books, movies, and TV shows, `send(.itemSaved)` was happening **after** the cover image download, which could block dismissal for several seconds; moved it to right after the DB write so the sheet dismisses instantly while the image fetches in the background (restaurants already did this correctly)