### PR TITLE
Fix CloudKit sharing: recipient sync, PrivateDB error, and missing owner name

### DIFF
--- a/Traveling Snails Tests/Unit Tests/Features/CollectionSharingTests.swift
+++ b/Traveling Snails Tests/Unit Tests/Features/CollectionSharingTests.swift
@@ -174,10 +174,11 @@ struct CollectionSharingTests {
             ),
         ]
 
-        await store.send(.shareStatusLoaded(isShared: true, canWrite: true, participants: participants)) {
+        await store.send(.shareStatusLoaded(isShared: true, canWrite: true, isOwner: true, participants: participants)) {
             $0.isLoadingParticipants = false
             $0.isShared = true
             $0.canWrite = true
+            $0.isOwner = true
             $0.participants = participants
         }
     }
@@ -193,10 +194,57 @@ struct CollectionSharingTests {
         }
         store.exhaustivity = .off
 
-        await store.send(.shareStatusLoaded(isShared: true, canWrite: false, participants: [])) {
+        await store.send(.shareStatusLoaded(isShared: true, canWrite: false, isOwner: false, participants: [])) {
             $0.isLoadingParticipants = false
             $0.isShared = true
             $0.canWrite = false
+            $0.isOwner = false
+        }
+    }
+
+    @Test("Manage share tapped as non-owner shows participants", .tags(.unit, .fast, .sharing))
+    func manageShareNonOwner() async throws {
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: Collection(name: "Test", type: .movie),
+                isShared: true,
+                isOwner: false
+            )
+        ) {
+            CollectionDetailFeature()
+        }
+        store.exhaustivity = .off
+
+        await store.send(.manageShareTapped) {
+            $0.showingParticipants = true
+        }
+    }
+
+    @Test("Manage share tapped as owner sets preparing state", .tags(.unit, .fast, .sharing))
+    func manageShareOwner() async throws {
+        let db = try DatabaseQueue(path: ":memory:")
+        try makeMigrator().migrate(db)
+
+        let collection = Collection(name: "Test", type: .movie)
+        try await db.write { db in
+            try Collection.upsert { collection }.execute(db)
+        }
+
+        let store = TestStore(
+            initialState: CollectionDetailFeature.State(
+                collection: collection,
+                isShared: true,
+                isOwner: true
+            )
+        ) {
+            CollectionDetailFeature()
+        } withDependencies: {
+            $0.defaultDatabase = db
+        }
+        store.exhaustivity = .off
+
+        await store.send(.manageShareTapped) {
+            $0.isPreparingShare = true
         }
     }
 

--- a/Traveling Snails/Features/CollectionDetailFeature.swift
+++ b/Traveling Snails/Features/CollectionDetailFeature.swift
@@ -55,6 +55,7 @@ struct CollectionDetailFeature {
         var showingParticipants = false
         var isShared = false
         var canWrite = true
+        var isOwner = true
     }
 
     enum Action: Equatable {
@@ -76,7 +77,10 @@ struct CollectionDetailFeature {
         case toggleParticipantSheet
 
         case loadShareStatus
-        case shareStatusLoaded(isShared: Bool, canWrite: Bool, participants: [ShareParticipant])
+        case shareStatusLoaded(isShared: Bool, canWrite: Bool, isOwner: Bool, participants: [ShareParticipant])
+
+        case leaveShareTapped
+        case fetchSharedZoneChanges
 
         case editNameTapped
         case editedNameChanged(String)
@@ -178,16 +182,21 @@ struct CollectionDetailFeature {
                 return .send(.loadShareStatus)
 
             case .manageShareTapped:
-                guard !state.isPreparingShare else { return .none }
-                state.isPreparingShare = true
-                let collection = state.collection
-                return .run { [syncEngine] send in
-                    do {
-                        let record = try await syncEngine.share(record: collection) { _ in }
-                        await send(.shareCreated(record))
-                    } catch {
-                        await send(.shareFailed(error.localizedDescription))
+                if state.isOwner {
+                    guard !state.isPreparingShare else { return .none }
+                    state.isPreparingShare = true
+                    let collection = state.collection
+                    return .run { [syncEngine] send in
+                        do {
+                            let record = try await syncEngine.share(record: collection) { _ in }
+                            await send(.shareCreated(record))
+                        } catch {
+                            await send(.shareFailed(error.localizedDescription))
+                        }
                     }
+                } else {
+                    state.showingParticipants = true
+                    return .none
                 }
 
             case .toggleParticipantSheet:
@@ -208,26 +217,69 @@ struct CollectionDetailFeature {
                     let isShared = share != nil
                     var participants: [ShareParticipant] = []
                     var canWrite = true
+                    var isOwner = true
                     if let share {
                         await userIdentityClient.cacheParticipantNames(share.participants)
                         participants = ShareParticipant.from(share: share)
                         let currentUser = share.currentUserParticipant
                         canWrite = currentUser?.permission == .readWrite
                             || share.owner == currentUser
+                        isOwner = share.owner == currentUser
                     }
                     await send(.shareStatusLoaded(
                         isShared: isShared,
                         canWrite: canWrite,
+                        isOwner: isOwner,
                         participants: participants
                     ))
                 }
 
-            case .shareStatusLoaded(let isShared, let canWrite, let participants):
+            case .shareStatusLoaded(let isShared, let canWrite, let isOwner, let participants):
                 state.isLoadingParticipants = false
                 state.isShared = isShared
                 state.canWrite = canWrite
+                state.isOwner = isOwner
                 state.participants = participants
+                if isShared && !isOwner {
+                    return .send(.fetchSharedZoneChanges)
+                }
                 return .none
+
+            case .fetchSharedZoneChanges:
+                let metadataID = state.collection.syncMetadataID
+                return .run { [syncEngine, database] _ in
+                    // Read the shared zone from SyncMetadata. The shared
+                    // CKSyncEngine may only do DatabaseChanges (zone discovery)
+                    // and skip ZoneChanges (actual record fetch) if the change
+                    // token is up to date. Passing a specific zone scope forces
+                    // the ZoneChanges fetch.
+                    let lastKnownRecord = try? await database.read { db in
+                        try SyncMetadata
+                            .find(metadataID)
+                            .select(\._lastKnownServerRecordAllFields)
+                            .fetchOne(db)
+                            ?? nil
+                    }
+                    if let lastKnownRecord,
+                       lastKnownRecord.recordID.zoneID.ownerName != CKCurrentUserDefaultName
+                    {
+                        try? await syncEngine.fetchChanges(
+                            CKSyncEngine.FetchChangesOptions(
+                                scope: .zoneIDs([lastKnownRecord.recordID.zoneID])
+                            )
+                        )
+                    } else {
+                        try? await syncEngine.fetchChanges()
+                    }
+                }
+
+            case .leaveShareTapped:
+                let collectionID = state.collection.id
+                return .run { [database] _ in
+                    try await database.write { db in
+                        try Collection.find(collectionID).delete().execute(db)
+                    }
+                }
 
             case .editNameTapped:
                 state.isEditingName = true

--- a/Traveling Snails/Models/CollectionRow.swift
+++ b/Traveling Snails/Models/CollectionRow.swift
@@ -27,10 +27,12 @@ struct CollectionRow: Identifiable {
             } else {
                 return "Shared"
             }
-        } else if let ownerName = share.owner.userIdentity.nameComponents?.formatted() {
-            return "Shared by \(ownerName)"
         } else {
-            return nil
+            let ownerName = share.owner.userIdentity.nameComponents?.formatted() ?? ""
+            if ownerName.trimmingCharacters(in: .whitespaces).isEmpty {
+                return "Shared with you"
+            }
+            return "Shared by \(ownerName)"
         }
     }
 

--- a/Traveling Snails/Views/Collections/CollectionDetailView.swift
+++ b/Traveling Snails/Views/Collections/CollectionDetailView.swift
@@ -218,9 +218,14 @@ struct CollectionDetailView: View {
         )) {
             ParticipantListView(
                 participants: store.state.participants,
+                isOwner: store.state.isOwner,
                 onManageSharing: {
                     store.send(.toggleParticipantSheet)
                     store.send(.manageShareTapped)
+                },
+                onLeaveShare: {
+                    store.send(.toggleParticipantSheet)
+                    store.send(.leaveShareTapped)
                 }
             )
             .frame(minWidth: 280)

--- a/Traveling Snails/Views/Collections/ParticipantListView.swift
+++ b/Traveling Snails/Views/Collections/ParticipantListView.swift
@@ -7,7 +7,9 @@ import SwiftUI
 
 struct ParticipantListView: View {
     let participants: [ShareParticipant]
+    var isOwner: Bool = true
     let onManageSharing: () -> Void
+    var onLeaveShare: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -22,11 +24,19 @@ struct ParticipantListView: View {
             Divider()
                 .padding(.vertical, 8)
 
-            Button(action: onManageSharing) {
-                Label("Manage Sharing", systemImage: "person.badge.plus")
+            if isOwner {
+                Button(action: onManageSharing) {
+                    Label("Manage Sharing", systemImage: "person.badge.plus")
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            } else if let onLeaveShare {
+                Button(role: .destructive, action: onLeaveShare) {
+                    Label("Leave Share", systemImage: "person.badge.minus")
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
         }
         .padding(.vertical, 8)
     }


### PR DESCRIPTION
## Summary

- **PrivateDB crash fix**: Share recipients tapping the sharing icon no longer crash. `syncEngine.share()` is owner-only — non-owners now see the participant sheet directly instead.
- **Item sync fix**: Shared collection items (movies, books, etc.) weren't syncing to recipients. CloudKit telemetry confirmed the shared CKSyncEngine was only doing `DatabaseChanges` (zone discovery) and skipping `ZoneChanges` (record download) due to a stale change token. Now forces a zone-specific `fetchChanges` with the shared zone ID after detecting the user is a recipient, which triggers `ZoneChanges` regardless.
- **"Shared by" name fix**: Falls back to "Shared with you" when CKShare system fields don't include resolved owner name components.
- **Leave Share**: Non-owners now see a "Leave Share" option in the participant list instead of "Manage Sharing".